### PR TITLE
Keep music playing when window is "closed" in macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Download
 
 [Download latest release](https://github.com/leyanlo/electron-pandora/releases/latest) (macOS and Linux)
- 
+
 ## Screenshot
 
 <img src="screenshot.png" width="640">
@@ -33,11 +33,11 @@ git clone https://github.com/leyanlo/electron-pandora
 # Go into the repository
 cd electron-pandora
 # Install dependencies
-npm install
+yarn
 # Run the app
-npm start
+yarn start
 # Build the app
-npm run package-mac # (or package-linux for Linux)
+yarn package-mac # (or package-linux for Linux)
 ```
 
 #### License [CC0 1.0 (Public Domain)](LICENSE.md)

--- a/main.js
+++ b/main.js
@@ -33,6 +33,17 @@ function createWindow() {
   // and load the index.html of the app.
   mainWindow.loadURL("https://www.pandora.com");
 
+  mainWindow.on('close', function (event) {
+    // On macOS, most users are used to an application continuing to run
+    // in the background when the window is closed. This emulates the
+    // same behavior and allows closing the window to continue playing the
+    // radio.
+    if (process.platform === 'darwin') {
+      event.preventDefault();
+      mainWindow.hide();
+    }
+  });
+
   // Emitted when the window is closed.
   mainWindow.on('closed', function () {
     // Dereference the window object, usually you would store windows
@@ -42,7 +53,8 @@ function createWindow() {
   });
 
   globalShortcut.register('mediaplaypause', function () {
-    // console.log('mediaplaypause pressed');
+    // When the playpause function key is pressed, toggle playback by
+    // using Pandora's spacebar shortcut.
     mainWindow.webContents.sendInputEvent({
       type: "keyDown",
       keyCode: "\u0020"
@@ -54,7 +66,8 @@ function createWindow() {
   });
 
   globalShortcut.register('medianexttrack', function () {
-    // console.log('medianexttrack pressed');
+    // When the nexttrack function key is pressed, skip to the next
+    // track using Pandora's right arrow key shortcut.
     mainWindow.webContents.sendInputEvent({
       type: "keyDown",
       keyCode: "right"
@@ -266,9 +279,16 @@ app.on('window-all-closed', function () {
 });
 
 app.on('activate', function () {
-  // On OS X it's common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
   if (mainWindow === null) {
+    // On macOS, reopen the app if there are no windows open but
+    // the application is running.
     createWindow()
+  } else if (!mainWindow.isVisible()) {
+    // If the window is open but hidden (i.e. closed by a macOS
+    // user and running in the background), show it.
+    mainWindow.show();
+  } else {
+    // If the window is already open, bring it to the forefront.
+    mainWindow.focus();
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Pandora",
+  "name": "electron-pandora",
   "version": "0.1.1",
   "description": "A Pandora Electron application",
   "main": "main.js",


### PR DESCRIPTION
On macOS, I think it is pretty common to close the window of an app that is playing audio and have it continue (iTunes and Spotify do this). I like having fewer windows open as well, so this adds the ability to keep the audio playing while the window is "closed" (hidden).