### PR TITLE
Fix quit behavior in macOS

### DIFF
--- a/main.js
+++ b/main.js
@@ -85,6 +85,38 @@ function createWindow() {
 function createDefaultMenu() {
   const template = [
     {
+      label: 'Edit',
+      submenu: [
+        {
+          role: 'undo'
+        },
+        {
+          role: 'redo'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          role: 'cut'
+        },
+        {
+          role: 'copy'
+        },
+        {
+          role: 'paste'
+        },
+        {
+          role: 'pasteandmatchstyle'
+        },
+        {
+          role: 'delete'
+        },
+        {
+          role: 'selectall'
+        }
+      ]
+    },
+    {
       label: 'View',
       submenu: [
         {

--- a/main.js
+++ b/main.js
@@ -282,6 +282,10 @@ app.on('window-all-closed', function () {
   }
 });
 
+app.on('will-quit', function () {
+  globalShortcut.unregisterAll();
+});
+
 app.on('activate', function () {
   if (mainWindow === null) {
     // On macOS, reopen the app if there are no windows open but

--- a/main.js
+++ b/main.js
@@ -34,12 +34,13 @@ function createWindow() {
   // and load the index.html of the app.
   mainWindow.loadURL("https://www.pandora.com");
 
-  mainWindow.on('close', function () {
+  mainWindow.on('close', function (event) {
     // On macOS, most users are used to an application continuing to run
     // in the background when the window is closed. This emulates the
     // same behavior and allows closing the window to continue playing the
     // radio.
-    if (process.platform === 'darwin') {
+    if (process.platform === 'darwin' && !quitOnClose) {
+      event.preventDefault();
       mainWindow.hide();
     }
   });
@@ -246,14 +247,6 @@ app.on('window-all-closed', function () {
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
     app.quit();
-  }
-});
-
-app.on('will-quit', function (event) {
-  // Prevent quitting when the main window is closed, unless the
-  // user quit with Cmd + Q.
-  if (process.platform === 'darwin' && !quitOnClose) {
-    event.preventDefault();
   }
 });
 


### PR DESCRIPTION
In the dev build, Cmd + Q always terminates the Electron process, so I didn't catch this until running an actual build of the application. This fixes the behavior where hitting Quit in the menu or pressing Cmd + Q would not quit the app.

Note that you might need to disable and reenable accessibility permissions in macOS or you might get a crash error when quitting (although the app still quits). See https://github.com/electron/electron/issues/14837

Fixes a bug introduced by me in #5 