### PR TITLE
Update gitignore to ignore .nosync nodemodule folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 node_modules
 out/
+node_modules.nosync


### PR DESCRIPTION
Using a node_modules.nosync symlink allows the node_modules folder to be ignore by iCloud for users who store code in an iCloud synced drive.