### PR TITLE
Fix mac quit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 node_modules
 out/
+node_modules.nosync

--- a/main.js
+++ b/main.js
@@ -13,7 +13,6 @@ const {shell} = require('electron');
 let mainWindow;
 
 function createWindow() {
-  // Create the browser window.
   let mainWindowState = windowStateKeeper({
     defaultWidth: 1280,
     defaultHeight: 720
@@ -33,16 +32,27 @@ function createWindow() {
   // and load the index.html of the app.
   mainWindow.loadURL("https://www.pandora.com");
 
-  mainWindow.on('close', function (event) {
-    // On macOS, most users are used to an application continuing to run
-    // in the background when the window is closed. This emulates the
-    // same behavior and allows closing the window to continue playing the
-    // radio.
-    if (process.platform === 'darwin') {
-      event.preventDefault();
-      mainWindow.hide();
-    }
-  });
+  // Only register Mac specific listeners if on Mac
+  if(process.platform === 'darwin') {
+    var wasForceQuit = false;
+
+    // Called before an app is quit. Should only be called when the app is actually quit ( https://electronjs.org/docs/api/app#event-before-quit )
+    app.on('before-quit', function(event) {
+      wasForceQuit = true;
+    })
+
+    mainWindow.on('close', function (event) {
+      // On macOS, most users are used to an application continuing to run
+      // in the background when the window is closed. This emulates the
+      // same behavior and allows closing the window to continue playing the
+      // radio.
+        if(!wasForceQuit) {
+          event.preventDefault();
+        }
+        mainWindow.hide();
+    });
+  }
+
 
   // Emitted when the window is closed.
   mainWindow.on('closed', function () {

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ const {shell} = require('electron');
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow;
+let wasForceQuit = false;
 
 function createWindow() {
   let mainWindowState = windowStateKeeper({
@@ -33,13 +34,6 @@ function createWindow() {
 
   // Only register Mac specific listeners if on Mac
   if(process.platform === 'darwin') {
-    var wasForceQuit = false;
-
-    // Called before an app is quit. Should only be called when the app is actually quit ( https://electronjs.org/docs/api/app#event-before-quit )
-    app.on('before-quit', function(event) {
-      wasForceQuit = true;
-    })
-
     mainWindow.on('close', function (event) {
       // On macOS, most users are used to an application continuing to run
       // in the background when the window is closed. This emulates the
@@ -282,14 +276,24 @@ function createDefaultMenu() {
 // Some APIs can only be used after this event occurs.
 app.on('ready', createWindow);
 
-// Quit when all windows are closed.
-app.on('window-all-closed', function () {
-  // On OS X it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
-    app.quit();
-  }
-});
+if(process.platform === 'darwin') {
+    // MacOS Listeners
+
+    // Called before an app is quit. Should only be called when the app is actually quit ( https://electronjs.org/docs/api/app#event-before-quit )
+    app.on('before-quit', function() {
+        wasForceQuit = true;
+    });
+
+} else {
+    // All other operating systems
+
+    // Quit when all windows are closed.
+    // This is excluded from Darwin as in OS X it is common for applications and
+    // their menu bar to stay active until the user quits explicitly with Cmd + Q
+    app.on('window-all-closed', function () {
+        app.quit();
+    });
+}
 
 app.on('activate', function () {
   if (mainWindow === null) {

--- a/main.js
+++ b/main.js
@@ -29,7 +29,6 @@ function createWindow() {
   });
 
   mainWindowState.manage(mainWindow);
-  // and load the index.html of the app.
   mainWindow.loadURL("https://www.pandora.com");
 
   // Only register Mac specific listeners if on Mac
@@ -59,12 +58,12 @@ function createWindow() {
     // Dereference the window object, usually you would store windows
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
-    mainWindow = null
+    mainWindow = null;
   });
 
   globalShortcut.register('mediaplaypause', function () {
-    // When the playpause function key is pressed, toggle playback by
-    // using Pandora's spacebar shortcut.
+    // When the 'playpause' function key is pressed, toggle playback by
+    // using Pandora's 'spacebar' shortcut.
     mainWindow.webContents.sendInputEvent({
       type: "keyDown",
       keyCode: "\u0020"
@@ -92,7 +91,8 @@ function createWindow() {
 }
 
 function createDefaultMenu() {
-  if (Menu.getApplicationMenu()) return;
+  if (Menu.getApplicationMenu())
+      return;
 
   const template = [
     {
@@ -132,6 +132,9 @@ function createDefaultMenu() {
       submenu: [
         {
           role: 'reload'
+        },
+        {
+          role: 'forceReload'
         },
         {
           role: 'toggledevtools'
@@ -267,7 +270,7 @@ function createDefaultMenu() {
           role: 'quit'
         }
       ]
-    })
+    });
   }
 
   const menu = Menu.buildFromTemplate(template);
@@ -284,7 +287,7 @@ app.on('window-all-closed', function () {
   // On OS X it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
-    app.quit()
+    app.quit();
   }
 });
 
@@ -292,7 +295,7 @@ app.on('activate', function () {
   if (mainWindow === null) {
     // On macOS, reopen the app if there are no windows open but
     // the application is running.
-    createWindow()
+    createWindow();
   } else if (!mainWindow.isVisible()) {
     // If the window is open but hidden (i.e. closed by a macOS
     // user and running in the background), show it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-pandora",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A Pandora Electron application",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Different approach of solving the quit issue referenced in #6 .

This approach allows keeping the “quit” role, to be more in line with standard menus.

Also adds the “Force Reload” option to allow refreshing without cache. I’ve been running into some issues recently with Pandora cache files becoming old or corrupt and cache refresh is the fix. This also brings the app more inline with Chromes standard refresh shortcuts( initially added in electron/electron#8465 )
